### PR TITLE
Improvement/fix scss rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "Mostly sane Stylelint rules for Ultimaker web-based projects",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Mostly sane Stylelint rules for Ultimaker web-based projects",
   "main": "index.js",
   "files": [

--- a/rules/scss.js
+++ b/rules/scss.js
@@ -1,5 +1,6 @@
 module.exports = {
     rules: {
+        'at-rule-blacklist': ['debug', 'extend'],
         'at-rule-no-unknown': [
             true,
             {

--- a/scss.js
+++ b/scss.js
@@ -1,3 +1,3 @@
 module.exports = {
-    extends: ['./rules/scss.js', './index.js'],
+    extends: ['./index.js', './rules/scss.js'],
 };

--- a/scss.js
+++ b/scss.js
@@ -1,30 +1,3 @@
 module.exports = {
     extends: ['./rules/scss.js', './index.js'],
-    rules: {
-        // At-rules
-        'at-rule-blacklist': ['debug', 'extend'],
-        'at-rule-no-unknown': [
-            true,
-            {
-                // this set excludes '@extend'
-                ignoreAtRules: [
-                    'use',
-                    'forward',
-                    'import',
-                    'mixin',
-                    'include',
-                    'function',
-                    'return',
-                    'error',
-                    'warn',
-                    'debug',
-                    'if',
-                    'else',
-                    'each',
-                    'for',
-                    'while',
-                ],
-            },
-        ],
-    },
 };


### PR DESCRIPTION
`./scss.js` should only extend
`./rules/scss.js` now contain the actual SCSS rules

`@extend` and `@debug` are considered valid at-rules in SCSS but are now
on the blacklist so they only generate one violation when used instead
of two.