### PR TITLE
Improvement/value list comma space after

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Mostly sane Stylelint rules for Ultimaker web-based projects",
   "main": "index.js",
   "files": [

--- a/rules/stylistic.js
+++ b/rules/stylistic.js
@@ -64,7 +64,7 @@ module.exports = {
         // Value list
         'value-list-comma-newline-after': 'always-multi-line',
         'value-list-comma-newline-before': 'never-multi-line',
-        'value-list-comma-space-after': 'always',
+        'value-list-comma-space-after': 'always-single-line',
         'value-list-comma-space-before': 'never',
         'value-list-max-empty-lines': 0,
 


### PR DESCRIPTION
Change value-list-comma-space-after from "always" to "always-single-line"

Used in, for example, value lists for multiple backgrounds. Every value needs
to be on its own line.

```SCSS
// good because single-line
.foo {
    transition: background-color 200ms ease-in-out, color 200ms ease-in-out;
}

// good because multi-line 
.foo {
    transition: background-color 200ms ease-in-out,
        color 200ms ease-in-out,
        opacity 200ms ease-in-out;
}

// bad because not all multi-line
.bar {
    transition: background-color 200ms ease-in-out, color 200ms ease-in-out,
       opacity 200ms ease-in-out;
//
```