### PR TITLE
Improvement font-weight-notation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "Mostly sane Stylelint rules for Ultimaker web-based projects",
   "main": "index.js",
   "files": [

--- a/rules/stylistic.js
+++ b/rules/stylistic.js
@@ -10,7 +10,7 @@ module.exports = {
         'font-family-name-quotes': 'always-where-recommended',
 
         // Font weight
-        'font-weight-notation': 'named-where-possible',
+        'font-weight-notation': 'numeric',
 
         // Function
         'function-comma-newline-after': 'always-multi-line',


### PR DESCRIPTION
Ultimaker designs uses several weights besides 'normal', that do
not nicely correspond with named weights in CSS. To keep CSS consistent
we will enforce numeric weight notation.

```SCSS
// good
.foo {
    font-weight: 400;
}

// good, "default" bold that Ultimaker designs use
.foo {
    font-weight: 500;
}

// bad, because inconsistent
.bar {
    font-weight: normal;
}

// worse, bold corresponds with a font weight of 700 that we do not have
.bar {
    font-weight: bold;
}
```