### PR TITLE
Improvement/hex colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "Mostly sane Stylelint rules for Ultimaker web-based projects",
   "main": "index.js",
   "files": [

--- a/rules/limit.js
+++ b/rules/limit.js
@@ -4,7 +4,7 @@ module.exports = {
     rules: {
         // Color
         'color-named': 'never',
-        // 'color-no-hex': null,
+        'color-no-hex': true,
 
         // Function
         // 'function-blacklist': [],

--- a/rules/stylistic.js
+++ b/rules/stylistic.js
@@ -3,8 +3,8 @@
 module.exports = {
     rules: {
         // Color
-        'color-hex-case': 'lower',
-        'color-hex-length': 'short',
+        'color-hex-case': null,
+        'color-hex-length': null,
 
         // Font family
         'font-family-name-quotes': 'always-where-recommended',

--- a/test/styles.css
+++ b/test/styles.css
@@ -26,8 +26,8 @@ a:hover {
 }
 
 button {
-    background-color: #ff1493;
-    color: #fff;
+    background-color: rgb(255, 14, 147);
+    color: rgb(255, 255, 255);
 }
 
 button[disabled] {

--- a/test/styles.scss
+++ b/test/styles.scss
@@ -1,5 +1,8 @@
 @import "partial";
 
+$white: rgb(255, 255, 255);
+$deeppink: rgb(255, 14, 147);
+
 *::before,
 *,
 *::after {
@@ -28,8 +31,8 @@ a {
 }
 
 button {
-    background-color: #ff1493;
-    color: #fff;
+    background-color: $deeppink;
+    color: $white;
 
     &[disabled] {
         background-color: rgb(128, 128, 128);


### PR DESCRIPTION
Disallow hex colors.

Updating react-web-components was trivial and this avoids discussions about long or short hex formats.