### PR TITLE
Fix version requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "typescript": "^3.6.3"
   },
   "peerDependencies": {
-    "stylelint": "^11.0.0"
+    "stylelint": "^11.0.0 || ^12.0.0 || ^13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimaker/stylelint-config",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Mostly sane Stylelint rules for Ultimaker web-based projects",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Stylelint have released versions 12 and 13 in fairly rapid succession without anything actually breaking for us.

I have updated the peerDependency to support all versions.

The version bump from 1.1.0 to 1.1.2 seems weird but that's simply because nobody bothered to merge [the branch](https://github.com/Ultimaker/stylelint-config/pull/14) in which 1.1.1 was released.