### PR TITLE
Allow the extend rule

### DIFF
--- a/rules/scss.js
+++ b/rules/scss.js
@@ -1,6 +1,6 @@
 module.exports = {
     rules: {
-        'at-rule-blacklist': ['debug', 'extend'],
+        'at-rule-blacklist': ['debug'],
         'at-rule-no-unknown': [
             true,
             {


### PR DESCRIPTION
It can be useful sometimes. Just don't abuse it.

[Here's a perfect example of where it should be used in `stardust-web`.](https://github.com/Ultimaker/stardust-web/pull/165/files#diff-bf2ca30b371ce153d08226fdb9ede52e)